### PR TITLE
use next versions of level-packager and leveldown-hyper

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "main": "level-hyper.js",
   "dependencies": {
-    "level-packager": "~0.19.3",
-    "leveldown-hyper": "~0.10.5"
+    "level-packager": "next",
+    "leveldown-hyper": "next"
   },
   "devDependencies": {
     "tape": "~4.0.0"


### PR DESCRIPTION
This will pull down `level-packager@1.0.0-0` and `leveldown-hyper@1.0.0-0`. Will release this as `level-hyper@1.0.0-0`