### PR TITLE
update leveldown-hyper to 1.1.0 (for prebuilt binaries)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "main": "level-hyper.js",
   "dependencies": {
     "level-packager": "~1.0.0",
-    "leveldown-hyper": "~1.0.0"
+    "leveldown-hyper": "~1.1.0"
   },
   "devDependencies": {
     "tape": "~4.0.0"


### PR DESCRIPTION
I propose we release a new minor.