### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
+sudo: false
+
 language: node_js
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
+before_install:
+  - export JOBS=max
 
 node_js:
   - "5"
   - "4"
-  - "3"
-  - "2"
-  - "1.8"
-  - "1.0"
   - "0.12"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "main": "level-hyper.js",
   "dependencies": {
     "level-packager": "~1.2.0",
-    "leveldown-hyper": "~1.1.0"
+    "leveldown-hyper": "~1.1.1"
   },
   "devDependencies": {
     "tape": "^4.2.2"


### PR DESCRIPTION
In the event of no prebuilt `leveldown-hyper` binaries, `level-hyper` will fallback to building `leveldown-hyper` from source and this requires at least gcc 4.8