### PR TITLE
update leveldown-hyper because of Level/leveldown-hyper#21

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "main": "level-hyper.js",
   "dependencies": {
     "level-packager": "~1.2.0",
-    "leveldown-hyper": "~1.1.1"
+    "leveldown-hyper": "^1.1.2"
   },
   "devDependencies": {
     "tape": "^4.2.2"


### PR DESCRIPTION
NAN is creating binaries that break during runtime in higher versions of node.
This was fixed when updating NAN dependency of leveldown-hyper